### PR TITLE
added basic load testing suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,5 @@ More info on Orleans [here](https://dotnet.github.io/orleans/Documentation/resou
 ## Future plans
 
 - [Event-sourced](https://dotnet.github.io/orleans/Documentation/grains/event_sourcing/index.html) actor state
-- Scalability and load testing (multiple app service nodes, etc.)
+- Scalability and load testing (multiple ACI nodes, etc.)
 - Node.js and/or Python interop (define actor logic in Node or Python, with a common .NET foundation)

--- a/frontend/MessagesController.cs
+++ b/frontend/MessagesController.cs
@@ -33,5 +33,16 @@ namespace Frontend
 
             return messages.ToArray();
         }
+
+        [HttpPost]
+        [Route("{actorId}")]
+        public async Task AddMessage(long actorId, [FromBody] string message)
+        {
+            _log.LogInformation("Adding a message");
+
+            var actor = _client.GetGrain<IMessageActor>(actorId);
+
+            await actor.AddMessage(message).ConfigureAwait(false);
+        }
     }
 }

--- a/loadtest/locust-load-test.sh
+++ b/loadtest/locust-load-test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run -p 8089:8089 -v $PWD:/mnt/locust locustio/locust -f /mnt/locust/locustfile.py

--- a/loadtest/locustfile.py
+++ b/loadtest/locustfile.py
@@ -1,0 +1,20 @@
+import string
+import random
+from locust import HttpUser, task, between
+
+class MessageActorUser(HttpUser):
+    wait_time = between(0.5, 2)
+
+    @task(2)
+    def add_message(self):
+        actor_id = random.randint(1, 100)
+        self.client.post(f"/messages/{actor_id}", json=self.__get_random_text())
+
+    @task
+    def get_messages(self):
+        actor_id = random.randint(1, 100)
+        self.client.get(f"/messages/{actor_id}")
+
+    def __get_random_text(self):
+        length = random.randint(10, 50)
+        return ''.join(random.choices(string.ascii_uppercase + string.digits, k = length))


### PR DESCRIPTION
Added support for using https://locust.io/ for load testing. Includes a bash script for running locust in a Docker container, with a simple Python-based test script.